### PR TITLE
ステージング環境のパスをホームディレクトリ配下に変更

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -42,7 +42,7 @@ set :ssh_options, {
 # Staging specific settings
 set :rails_env, 'staging'
 set :branch, ENV['BRANCH'] || 'develop'
-set :deploy_to, '/var/www/yoyaku-hub-staging'
+set :deploy_to, '/home/debian/yoyaku-hub-staging'
 
 # Puma settings for staging
 set :puma_bind, "unix://#{shared_path}/tmp/sockets/puma-staging.sock"

--- a/config/nginx/staging-yoyaku-hub.conf
+++ b/config/nginx/staging-yoyaku-hub.conf
@@ -3,7 +3,7 @@
 # Then create a symlink: sudo ln -s /etc/nginx/sites-available/staging-yoyaku-hub /etc/nginx/sites-enabled/
 
 upstream staging_puma {
-  server unix:///var/www/yoyaku-hub-staging/shared/tmp/sockets/puma-staging.sock;
+  server unix:///home/debian/yoyaku-hub-staging/shared/tmp/sockets/puma-staging.sock;
 }
 
 server {
@@ -27,9 +27,9 @@ server {
   ssl_ciphers HIGH:!aNULL:!MD5;
   ssl_prefer_server_ciphers on;
 
-  root /var/www/yoyaku-hub-staging/current/public;
-  access_log /var/www/yoyaku-hub-staging/shared/log/nginx.access.log;
-  error_log /var/www/yoyaku-hub-staging/shared/log/nginx.error.log info;
+  root /home/debian/yoyaku-hub-staging/current/public;
+  access_log /home/debian/yoyaku-hub-staging/shared/log/nginx.access.log;
+  error_log /home/debian/yoyaku-hub-staging/shared/log/nginx.error.log info;
 
   # Basic Authentication for staging environment
   auth_basic "Staging Environment";


### PR DESCRIPTION
- /var/www/yoyaku-hub-staging から /home/debian/yoyaku-hub-staging へ変更
- 本番環境と同じディレクトリ構造に統一