### PR TITLE
デモデータ削除タスクのNoMethodErrorを修正

### DIFF
--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -52,10 +52,14 @@ class DemoDataCleaner
       deleted_count[:chartes] += user.stylist_chartes.count + user.customer_chartes.count
       deleted_count[:users] += 1
 
-      cleanup_user_data([user])
+      # 単一のユーザーを削除
+      user.reservations.destroy_all
+      user.stylist_reservations.destroy_all
+      user.stylist_chartes.destroy_all
+      user.customer_chartes.destroy_all
     end
 
-    @demo_users.destroy_all
+    @demo_users.reload.destroy_all
     deleted_count
   end
 


### PR DESCRIPTION
- perform_cleanupメソッド内で直接削除処理を実行するように変更
- cleanup_user_dataに配列を渡していた問題を解消
- 本番環境での実行エラーを修正